### PR TITLE
Fix login hint and preview visibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -278,11 +278,8 @@ def index():
     )
 
 @app.route('/preview/<int:qr_id>')
-@login_required
 def preview(qr_id):
     qr = QRCode.query.get_or_404(qr_id)
-    if qr.user_id != current_user.id:
-        return 'Unauthorized', 403
     directory = os.path.dirname(qr.png_path)
     filename = os.path.basename(qr.png_path)
     return send_from_directory(directory, filename)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,11 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>QR-Code Generator</h1>
+{% if not current_user.is_authenticated %}
+<div class="alert alert-info">
+    Bitte <a href="{{ url_for('login') }}">einloggen</a>, um QR-Codes zu erstellen und Vorschauen anzuzeigen.
+</div>
+{% endif %}
 <form method="post" class="row g-3 mb-4">
   <div class="col-md-6">
     <label class="form-label">URL</label>


### PR DESCRIPTION
## Summary
- show a login note on the start page if the user is not authenticated
- make preview images accessible without requiring login

## Testing
- `python -m py_compile app.py`
- manual curl calls to check page rendering and preview access

------
https://chatgpt.com/codex/tasks/task_e_6846e165ff5c8321b3af4e977d816af9