### PR TITLE
Automatic QR code sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Die Anwendung nutzt ein modernes Design auf Basis von Bootswatch.
 - Anmeldung über Google OAuth
 - Registrierung und Login per Benutzername und Passwort
 - Generieren von QR-Codes mit Farbe, Hintergrundfarbe und runden Ecken
+- Größe der QR-Codes passt sich automatisch dem Inhalt an
 - QR-Codes werden pro Benutzer gespeichert
 - Download als PNG, JPG oder SVG
 - Zu jedem QR-Code kann eine kurze Beschreibung hinterlegt werden

--- a/app.py
+++ b/app.py
@@ -180,7 +180,6 @@ def upgrade():
 
 def generate_qr_files(
     url,
-    size=10,
     color='black',
     bgcolor='white',
     rounded=False,
@@ -188,11 +187,15 @@ def generate_qr_files(
 ):
     qr = qrcode.QRCode(
         error_correction=qrcode.constants.ERROR_CORRECT_H,
-        box_size=size,
+        box_size=1,
         border=4,
     )
     qr.add_data(url)
     qr.make(fit=True)
+
+    # Adjust box size so the final image fits within 400px.
+    max_pixels = 400
+    qr.box_size = max(1, max_pixels // qr.modules_count)
 
     drawer = RoundedModuleDrawer() if rounded else None
     front = ImageColor.getcolor(color, "RGBA")
@@ -234,14 +237,12 @@ def index():
             flash('Limit für deinen Plan erreicht.')
             return redirect(url_for('index'))
         url_input = request.form.get('url')
-        size = int(request.form.get('size', 10))
         color = request.form.get('color', 'black')
         bgcolor = request.form.get('bgcolor', 'white')
         rounded = request.form.get('rounded') == 'on'
         description = request.form.get('description')
         qr_id, png_path, jpg_path, svg_path = generate_qr_files(
             url_input,
-            size=size,
             color=color,
             bgcolor=bgcolor,
             rounded=rounded,

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,10 +12,6 @@
     <input type="text" class="form-control" name="url" required>
   </div>
   <div class="col-md-2">
-    <label class="form-label">Größe</label>
-    <input type="number" class="form-control" name="size" value="10" min="1" max="20">
-  </div>
-  <div class="col-md-2">
     <label class="form-label">Farbe</label>
     <input type="color" class="form-control form-control-color" name="color" value="#000000">
   </div>


### PR DESCRIPTION
## Summary
- auto-scale QR codes to a maximum of 400 px
- drop manual size input from the UI
- note automatic sizing in the README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6846e3124ed483218ae363507e92ac5b