### PR TITLE
Fix QR code creation

### DIFF
--- a/app.py
+++ b/app.py
@@ -198,8 +198,8 @@ def generate_qr_files(
     qr.box_size = max(1, max_pixels // qr.modules_count)
 
     drawer = RoundedModuleDrawer() if rounded else None
-    front = ImageColor.getcolor(color, "RGBA")
-    back = ImageColor.getcolor(bgcolor, "RGBA")
+    front = ImageColor.getcolor(color, "RGB")
+    back = ImageColor.getcolor(bgcolor, "RGB")
     img = qr.make_image(
         image_factory=StyledPilImage,
         module_drawer=drawer,


### PR DESCRIPTION
## Summary
- fix color handling when generating QR codes so the images aren't blank

## Testing
- `python3 -m py_compile app.py`
- `python3 - <<'EOF'
from app import generate_qr_files
id,png,jpg,svg = generate_qr_files('https://example.com', color='#000000', bgcolor='#ffffff', rounded=False)
from PIL import Image
print('PNG colors', Image.open(png).getcolors(100000)[:5])
print('JPG colors', Image.open(jpg).getcolors(100000)[:5])
print('SVG size', len(open(svg,'rb').read()))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6846e4b6239c83219bdf4169329ffcfe