### PR TITLE
Remove Google OAuth and add profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ Ein einfacher QR-Code Generator als Flask-Webanwendung.
 Die Anwendung nutzt ein modernes Design auf Basis von Bootswatch.
 
 ## Funktionen
-- Anmeldung über Google OAuth
-- Registrierung und Login per Benutzername und Passwort
+- Registrierung (mit Email) und Login per Benutzername und Passwort
 - Generieren von QR-Codes mit Farbe, Hintergrundfarbe und runden Ecken
 - Größe der QR-Codes passt sich automatisch dem Inhalt an
 - QR-Codes werden pro Benutzer gespeichert

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 flask
 flask_sqlalchemy
 flask_login
-flask_dance
 qrcode[pil]
 Pillow

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,12 +16,12 @@
                 {% if current_user.username == 'DO1FFE' %}
                 <a class="btn btn-outline-warning me-2" href="{{ url_for('admin_panel') }}">Admin</a>
                 {% endif %}
+                <a class="btn btn-outline-secondary me-2" href="{{ url_for('profile') }}">Profil</a>
                 <a class="btn btn-outline-secondary me-2" href="{{ url_for('upgrade') }}">Upgrade</a>
                 <a class="btn btn-outline-secondary" href="{{ url_for('logout') }}">Logout</a>
             {% else %}
                 <a class="btn btn-outline-primary me-2" href="{{ url_for('login') }}">Login</a>
                 <a class="btn btn-outline-secondary me-2" href="{{ url_for('register') }}">Registrieren</a>
-                <a class="btn btn-outline-success" href="{{ url_for('login_google') }}">Login mit Google</a>
             {% endif %}
         </div>
     </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Profil bearbeiten</h1>
+<form method="post" style="max-width:400px;">
+  <div class="mb-3">
+    <label class="form-label">Benutzername</label>
+    <input type="text" class="form-control" name="username" value="{{ current_user.username }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" class="form-control" name="name" value="{{ current_user.name }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Email</label>
+    <input type="email" class="form-control" name="email" value="{{ current_user.email }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Neues Passwort</label>
+    <input type="password" class="form-control" name="password">
+  </div>
+  <button class="btn btn-primary" type="submit">Speichern</button>
+</form>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -7,6 +7,10 @@
     <input type="text" class="form-control" name="username" required>
   </div>
   <div class="mb-3">
+    <label class="form-label">Email</label>
+    <input type="email" class="form-control" name="email" required>
+  </div>
+  <div class="mb-3">
     <label class="form-label">Passwort</label>
     <input type="password" class="form-control" name="password" required>
   </div>

--- a/templates/upgrade.html
+++ b/templates/upgrade.html
@@ -22,6 +22,7 @@
     <input type="hidden" name="src" value="1">
     <button class="btn btn-outline-primary">Starter für 1,99€/Monat</button>
   </form>
+  <small class="text-muted">bis zu {{ PLAN_LIMITS['starter'] }} QR-Codes</small>
 </div>
 <div class="mb-3">
   <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
@@ -35,6 +36,7 @@
     <input type="hidden" name="src" value="1">
     <button class="btn btn-outline-primary">Pro für 4,99€/Monat</button>
   </form>
+  <small class="text-muted">bis zu {{ PLAN_LIMITS['pro'] }} QR-Codes</small>
 </div>
 <div class="mb-3">
   <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
@@ -48,6 +50,7 @@
     <input type="hidden" name="src" value="1">
     <button class="btn btn-outline-primary">Premium für 9,99€/Monat</button>
   </form>
+  <small class="text-muted">bis zu {{ PLAN_LIMITS['premium'] }} QR-Codes</small>
 </div>
 <div>
   <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
@@ -61,5 +64,6 @@
     <input type="hidden" name="src" value="1">
     <button class="btn btn-outline-primary">Unlimited für 19,99€/Monat</button>
   </form>
+  <small class="text-muted">unbegrenzte QR-Codes</small>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove Google OAuth remnants from codebase
- require email on registration
- add profile editing page
- enforce QR code limits when plans change
- update templates and docs
- show plan limits on the upgrade page

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6846e9af9dec8321aabbe2b7f0bf28bf