### PR TITLE
Reduce preview image size

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,2 +1,10 @@
 body {background-color: #f5f7fa;}
 footer {font-size: 0.9rem; color: #666;}
+
+.qr-preview {
+  width: 50%;
+  height: auto;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,7 +41,7 @@
   {% for qr in qrcodes %}
   <div class="col">
     <div class="card h-100">
-      <img src="{{ url_for('preview', qr_id=qr.id) }}" class="card-img-top" alt="QR-Code">
+      <img src="{{ url_for('preview', qr_id=qr.id) }}" class="card-img-top qr-preview" alt="QR-Code">
       <div class="card-body">
         <h5 class="card-title">{{ qr.description or 'QR Code' }}</h5>
         <p class="card-text"><a href="{{ qr.url }}" target="_blank">{{ qr.url }}</a></p>


### PR DESCRIPTION
## Summary
- shrink QR code preview images to 50%

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6846f4666b4c8321b2891acc89a9c8e3