### PR TITLE
Add subscription cancellation and remaining quota notice

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2,7 +2,7 @@ body {background-color: #f5f7fa;}
 footer {font-size: 0.9rem; color: #666;}
 
 .qr-preview {
-  width: 50%;
+  width: 25%;
   height: auto;
   display: block;
   margin-left: auto;

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,15 @@
   <div class="col-12">
     <button type="submit" class="btn btn-primary" {% if limit_reached %}disabled{% endif %}>Erstellen</button>
   </div>
+  {% if remaining is not none and limit is not none %}
+  <div class="col-12">
+    <small class="text-muted">Du kannst noch {{ remaining }} von {{ limit }} QR-Codes erstellen.</small>
+  </div>
+  {% elif limit is none and current_user.is_authenticated %}
+  <div class="col-12">
+    <small class="text-muted">Unbegrenzte QR-Codes verfügbar.</small>
+  </div>
+  {% endif %}
 </form>
 {% if limit_reached %}
 <div class="alert alert-warning">Limit erreicht. <a href="{{ url_for('upgrade') }}">Upgrade</a> notwendig.</div>
@@ -45,6 +54,7 @@
       <div class="card-body">
         <h5 class="card-title">{{ qr.description or 'QR Code' }}</h5>
         <p class="card-text"><a href="{{ qr.url }}" target="_blank">{{ qr.url }}</a></p>
+        <p class="card-text"><small class="text-muted">{{ qr.created_at_local.strftime('%d.%m.%Y %H:%M') }}</small></p>
         <div class="btn-group" role="group">
           <a href="{{ url_for('download', qr_id=qr.id, fmt='png') }}" class="btn btn-outline-secondary btn-sm">PNG</a>
           <a href="{{ url_for('download', qr_id=qr.id, fmt='jpg') }}" class="btn btn-outline-secondary btn-sm">JPG</a>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -20,4 +20,9 @@
   </div>
   <button class="btn btn-primary" type="submit">Speichern</button>
 </form>
+{% if current_user.plan != 'basic' %}
+<div class="mt-3">
+  <a class="btn btn-outline-danger" href="{{ url_for('cancel_subscription') }}">Abo kündigen</a>
+</div>
+{% endif %}
 {% endblock %}

--- a/templates/upgrade.html
+++ b/templates/upgrade.html
@@ -10,6 +10,7 @@
   <button class="btn btn-primary" type="submit">Code einlösen</button>
 </form>
 <h2>Bezahlen mit PayPal</h2>
+<p class="text-muted">Die Bezahlung über PayPal ist ein monatliches Abo. Bei Kündigung fällst du auf den BASIC-Plan zurück.</p>
 <div class="mb-3">
   <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
     <input type="hidden" name="cmd" value="_xclick-subscriptions">
@@ -22,7 +23,7 @@
     <input type="hidden" name="src" value="1">
     <button class="btn btn-outline-primary">Starter für 1,99€/Monat</button>
   </form>
-  <small class="text-muted">bis zu {{ PLAN_LIMITS['starter'] }} QR-Codes</small>
+  <small class="text-muted">bis zu {{ PLAN_LIMITS['starter'] }} QR-Codes – monatliches Abo</small>
 </div>
 <div class="mb-3">
   <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
@@ -36,7 +37,7 @@
     <input type="hidden" name="src" value="1">
     <button class="btn btn-outline-primary">Pro für 4,99€/Monat</button>
   </form>
-  <small class="text-muted">bis zu {{ PLAN_LIMITS['pro'] }} QR-Codes</small>
+  <small class="text-muted">bis zu {{ PLAN_LIMITS['pro'] }} QR-Codes – monatliches Abo</small>
 </div>
 <div class="mb-3">
   <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
@@ -50,7 +51,7 @@
     <input type="hidden" name="src" value="1">
     <button class="btn btn-outline-primary">Premium für 9,99€/Monat</button>
   </form>
-  <small class="text-muted">bis zu {{ PLAN_LIMITS['premium'] }} QR-Codes</small>
+  <small class="text-muted">bis zu {{ PLAN_LIMITS['premium'] }} QR-Codes – monatliches Abo</small>
 </div>
 <div>
   <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
@@ -64,6 +65,6 @@
     <input type="hidden" name="src" value="1">
     <button class="btn btn-outline-primary">Unlimited für 19,99€/Monat</button>
   </form>
-  <small class="text-muted">unbegrenzte QR-Codes</small>
+  <small class="text-muted">unbegrenzte QR-Codes – monatliches Abo</small>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show how many QR codes each user can still create
- explain PayPal plans are monthly subscriptions
- add route and button to cancel a subscription which reverts to BASIC
- display creation date/time in the preview and shrink images

## Testing
- `pip install -r requirements.txt`
- `python app.py` *(launches server)*

------
https://chatgpt.com/codex/tasks/task_e_6846f5d78d808321a09dd0e77ee9335f