### PR TITLE
Highlight active plan in upgrade view

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Es gibt mehrere Abomodelle:
 - **Unlimited** – 19,99€/Monat für unbegrenzte QR-Codes
 
 Die Bezahlung erfolgt über PayPal an `do1ffe@darc.de`.
+Möchtest du deinen Plan wechseln, kündige zunächst das bestehende PayPal-Abo und wähle anschließend ein neues Modell.

--- a/templates/upgrade.html
+++ b/templates/upgrade.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h1>Upgrade</h1>
 <p>Nutz deinen Rabattcode oder wähle einen kostenpflichtigen Plan.</p>
+<p class="text-muted">Um den Plan zu wechseln, kündige zuerst das bestehende PayPal-Abo und wähle danach einen neuen Plan.</p>
 <form method="post" class="mb-4" style="max-width:400px;">
   <div class="mb-3">
     <label class="form-label">Rabattcode</label>
@@ -21,7 +22,8 @@
     <input type="hidden" name="p3" value="1">
     <input type="hidden" name="t3" value="M">
     <input type="hidden" name="src" value="1">
-    <button class="btn btn-outline-primary">Starter für 1,99€/Monat</button>
+    <button class="btn {% if current_user.plan == 'starter' %}btn-primary{% else %}btn-outline-primary{% endif %}">Starter für 1,99€/Monat</button>
+    {% if current_user.plan == 'starter' %}<span class="badge bg-primary ms-2">Aktueller Plan</span>{% endif %}
   </form>
   <small class="text-muted">bis zu {{ PLAN_LIMITS['starter'] }} QR-Codes – monatliches Abo</small>
 </div>
@@ -35,7 +37,8 @@
     <input type="hidden" name="p3" value="1">
     <input type="hidden" name="t3" value="M">
     <input type="hidden" name="src" value="1">
-    <button class="btn btn-outline-primary">Pro für 4,99€/Monat</button>
+    <button class="btn {% if current_user.plan == 'pro' %}btn-primary{% else %}btn-outline-primary{% endif %}">Pro für 4,99€/Monat</button>
+    {% if current_user.plan == 'pro' %}<span class="badge bg-primary ms-2">Aktueller Plan</span>{% endif %}
   </form>
   <small class="text-muted">bis zu {{ PLAN_LIMITS['pro'] }} QR-Codes – monatliches Abo</small>
 </div>
@@ -49,7 +52,8 @@
     <input type="hidden" name="p3" value="1">
     <input type="hidden" name="t3" value="M">
     <input type="hidden" name="src" value="1">
-    <button class="btn btn-outline-primary">Premium für 9,99€/Monat</button>
+    <button class="btn {% if current_user.plan == 'premium' %}btn-primary{% else %}btn-outline-primary{% endif %}">Premium für 9,99€/Monat</button>
+    {% if current_user.plan == 'premium' %}<span class="badge bg-primary ms-2">Aktueller Plan</span>{% endif %}
   </form>
   <small class="text-muted">bis zu {{ PLAN_LIMITS['premium'] }} QR-Codes – monatliches Abo</small>
 </div>
@@ -63,7 +67,8 @@
     <input type="hidden" name="p3" value="1">
     <input type="hidden" name="t3" value="M">
     <input type="hidden" name="src" value="1">
-    <button class="btn btn-outline-primary">Unlimited für 19,99€/Monat</button>
+    <button class="btn {% if current_user.plan == 'unlimited' %}btn-primary{% else %}btn-outline-primary{% endif %}">Unlimited für 19,99€/Monat</button>
+    {% if current_user.plan == 'unlimited' %}<span class="badge bg-primary ms-2">Aktueller Plan</span>{% endif %}
   </form>
   <small class="text-muted">unbegrenzte QR-Codes – monatliches Abo</small>
 </div>


### PR DESCRIPTION
## Summary
- improve upgrade page with note to cancel PayPal subscription before switching plans
- highlight the active plan on the upgrade page
- document PayPal cancellation requirement in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684701e62dcc8321b9858982f8d85517