### PR TITLE
Enable dark theme

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,11 @@
-body {background-color: #e8f8f5; color: #000;}
-footer {font-size: 0.9rem; color: #666;}
+body {
+  background-color: #222;
+  color: #fff;
+}
+footer {
+  font-size: 0.9rem;
+  color: #ccc;
+}
 
 .qr-preview {
   width: 25%;

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>QR-Code Generator</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/minty/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/darkly/bootstrap.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- use Bootswatch Darkly theme instead of Minty
- update custom styles for dark layout

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684706760c088321853e0969ed01e8d5