### PR TITLE
Update plan selection logic

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -22,10 +22,16 @@
 </form>
 {% if current_user.plan != 'basic' %}
 <div class="mt-3">
+  {% if not current_user.plan_cancelled %}
   <a class="btn btn-outline-danger" href="{{ url_for('cancel_subscription') }}">Abo kündigen</a>
+  {% endif %}
 </div>
-{% if remaining %}
-<p class="mt-2 text-muted">Aktueller Plan läuft noch {{ remaining.days }} Tage.</p>
+{% if next_charge %}
+  {% if current_user.plan_cancelled %}
+  <p class="mt-2 text-muted">Plan endet am {{ next_charge.strftime('%d.%m.%Y') }}.</p>
+  {% else %}
+  <p class="mt-2 text-muted">Nächste Abbuchung am {{ next_charge.strftime('%d.%m.%Y') }}.</p>
+  {% endif %}
 {% endif %}
 {% endif %}
 {% endblock %}

--- a/templates/upgrade.html
+++ b/templates/upgrade.html
@@ -2,7 +2,18 @@
 {% block content %}
 <h1>Upgrade</h1>
 <p>Nutz deinen Rabattcode oder wähle einen kostenpflichtigen Plan.</p>
+{% if current_user.plan != 'basic' and next_charge %}
+  {% if current_user.plan_cancelled %}
+    <p class="text-muted">Aktueller Plan endet am {{ next_charge.strftime('%d.%m.%Y') }}.</p>
+  {% else %}
+    <p class="text-muted">Nächste Abbuchung am {{ next_charge.strftime('%d.%m.%Y') }}.</p>
+  {% endif %}
+{% endif %}
 <p class="text-muted">Um den Plan zu wechseln, kündige zuerst das bestehende PayPal-Abo und wähle danach einen neuen Plan.</p>
+{% if not allow_new_plan %}
+<div class="alert alert-warning">Du kannst einen neuen Plan erst nach Ablauf deines aktuellen Plans auswählen.</div>
+{% endif %}
+{% if allow_new_plan %}
 <form method="post" class="mb-4" style="max-width:400px;">
   <div class="mb-3">
     <label class="form-label">Rabattcode</label>
@@ -72,4 +83,5 @@
   </form>
   <small class="text-muted">unbegrenzte QR-Codes – monatliches Abo</small>
 </div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- restrict plan changes until the previous subscription expired
- display next payment date or cancellation status on profile
- show billing info and disable plan choice if a plan is still active

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684708d693cc832187162928edab91f7