### PR TITLE
Use absolute database path

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,7 +31,7 @@ from PIL import ImageColor
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev')
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///database.db'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////home/do1ffe/qrcode/database.db'
 app.config['UPLOAD_FOLDER'] = os.path.join(app.root_path, 'qrcodes')
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 


### PR DESCRIPTION
## Summary
- configure Flask to use the SQLite database at `/home/do1ffe/qrcode/database.db`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470f3ac6908321b774221c2a2c1dcf