### PR TITLE
Add name field during sign up

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,6 +114,7 @@ def check_plan_expiration():
 def register():
     if request.method == 'POST':
         username = request.form.get('username')
+        name = request.form.get('name')
         email = request.form.get('email')
         password = request.form.get('password')
         if User.query.filter_by(username=username).first():
@@ -124,6 +125,7 @@ def register():
             return redirect(url_for('register'))
         user = User(
             username=username,
+            name=name,
             email=email,
             password_hash=generate_password_hash(password),
         )

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,7 @@
         <a class="navbar-brand" href="{{ url_for('index') }}">QR-Code</a>
         <div class="d-flex">
             {% if current_user.is_authenticated %}
-                <span class="navbar-text me-2 text-white">{{ current_user.name or current_user.username }} – {{ current_user.plan|capitalize }}</span>
+                <span class="navbar-text me-2 text-white">{{ current_user.username }} – {{ current_user.plan|capitalize }}</span>
                 {% if current_user.username == 'DO1FFE' %}
                 <a class="btn btn-outline-warning me-2" href="{{ url_for('admin_panel') }}">Admin</a>
                 {% endif %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -7,6 +7,10 @@
     <input type="text" class="form-control" name="username" required>
   </div>
   <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" class="form-control" name="name" required>
+  </div>
+  <div class="mb-3">
     <label class="form-label">Email</label>
     <input type="email" class="form-control" name="email" required>
   </div>


### PR DESCRIPTION
## Summary
- collect and store the full name during registration
- always show logged in username in the navbar

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684714507f4883219a03ea800ead4e3f