### PR TITLE
Fix text brightness

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,9 @@
+/* Override Bootswatch variables for brighter text */
+:root {
+  --bs-body-color: #ffffff;
+  --bs-body-color-rgb: 255, 255, 255;
+}
+
 body {
   background-color: #222;
   color: #fff;
@@ -27,5 +33,5 @@ label.form-label {
 
 /* Lighten muted text for better readability on dark background */
 .text-muted {
-  color: #bbb !important;
+  color: #eee !important;
 }


### PR DESCRIPTION
## Summary
- lighten global text variables for brighter theme
- lighten color of `.text-muted` elements

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68471781c9548321907b489b4259afdd