### PR TITLE
Add transitions and upgrade styling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -9,6 +9,12 @@ body {
   color: #fff;
   font-size: 1.1rem;
   line-height: 1.5;
+  opacity: 0;
+  transition: opacity 0.4s ease-in-out;
+}
+
+body.page-loaded {
+  opacity: 1;
 }
 footer {
   font-size: 0.9rem;
@@ -39,4 +45,17 @@ label.form-label {
 /* Ensure button text is white for better visibility */
 .btn {
   color: #fff !important;
+}
+
+.btn:hover {
+  transform: scale(1.05);
+  transition: transform 0.2s ease-in-out;
+}
+
+.plan-card {
+  border: 1px solid #444;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+  background-color: #2a2a2a;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,5 +39,21 @@
 <footer class="text-center mt-4 mb-3">
     &copy; {{ current_year }} Erik Schauer
 </footer>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  document.body.classList.add('page-loaded');
+  document.querySelectorAll('a[href]').forEach(a => {
+    if (a.target === '_blank' || a.getAttribute('href').startsWith('#')) return;
+    a.addEventListener('click', e => {
+      if (e.ctrlKey || e.metaKey) return;
+      e.preventDefault();
+      document.body.classList.remove('page-loaded');
+      setTimeout(() => {
+        window.location.href = a.href;
+      }, 300);
+    });
+  });
+});
+</script>
 </body>
 </html>

--- a/templates/upgrade.html
+++ b/templates/upgrade.html
@@ -22,7 +22,7 @@
 </form>
 <h2>Bezahlen mit PayPal</h2>
 <p class="text-muted">Die Bezahlung über PayPal ist ein monatliches Abo. Bei Kündigung fällst du auf den BASIC-Plan zurück.</p>
-<div class="mb-3">
+<div class="mb-3 plan-card">
   <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
     <input type="hidden" name="cmd" value="_xclick-subscriptions">
     <input type="hidden" name="business" value="do1ffe@darc.de">
@@ -48,7 +48,7 @@
   </form>
   <small class="text-muted">bis zu {{ PLAN_LIMITS['starter'] }} QR-Codes – monatliches Abo</small>
 </div>
-<div class="mb-3">
+<div class="mb-3 plan-card">
   <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
     <input type="hidden" name="cmd" value="_xclick-subscriptions">
     <input type="hidden" name="business" value="do1ffe@darc.de">
@@ -74,7 +74,7 @@
   </form>
   <small class="text-muted">bis zu {{ PLAN_LIMITS['pro'] }} QR-Codes – monatliches Abo</small>
 </div>
-<div class="mb-3">
+<div class="mb-3 plan-card">
   <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
     <input type="hidden" name="cmd" value="_xclick-subscriptions">
     <input type="hidden" name="business" value="do1ffe@darc.de">
@@ -100,7 +100,7 @@
   </form>
   <small class="text-muted">bis zu {{ PLAN_LIMITS['premium'] }} QR-Codes – monatliches Abo</small>
 </div>
-<div>
+<div class="plan-card">
   <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
     <input type="hidden" name="cmd" value="_xclick-subscriptions">
     <input type="hidden" name="business" value="do1ffe@darc.de">


### PR DESCRIPTION
## Summary
- create fade effect between pages and animate button hover
- add plan-card styling to upgrade page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847198af804832180e1facc39cd4b40