### PR TITLE
Add Datenschutzerklärung page

### DIFF
--- a/app.py
+++ b/app.py
@@ -515,6 +515,16 @@ def delete_user(user_id):
     flash('Benutzer gelöscht')
     return redirect(url_for('admin_panel'))
 
+
+@app.route('/impressum')
+def impressum():
+    return render_template('impressum.html')
+
+
+@app.route('/datenschutz')
+def privacy():
+    return render_template('datenschutz.html')
+
 if __name__ == '__main__':
     with app.app_context():
         db.create_all()

--- a/templates/base.html
+++ b/templates/base.html
@@ -37,7 +37,9 @@
     {% block content %}{% endblock %}
 </div>
 <footer class="text-center mt-4 mb-3">
-    &copy; {{ current_year }} Erik Schauer
+    &copy; {{ current_year }} Erik Schauer –
+    <a href="{{ url_for('impressum') }}">Impressum</a> |
+    <a href="{{ url_for('privacy') }}">Datenschutzerklärung</a>
 </footer>
 <script>
 document.addEventListener('DOMContentLoaded', () => {

--- a/templates/datenschutz.html
+++ b/templates/datenschutz.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Datenschutzerklärung</h1>
+<p>Diese Datenschutzerklärung klärt Sie über die Art, den Umfang und Zweck der Verarbeitung von personenbezogenen Daten innerhalb unseres Onlineangebotes auf.</p>
+
+<h2>Verantwortlicher</h2>
+<p>
+Erik Schauer<br>
+Franziskanerhöhe 9<br>
+45139 Essen<br>
+E-Mail: <a href="mailto:do1ffe@darc.de">do1ffe@darc.de</a>
+</p>
+
+<h2>Zugriffsdaten</h2>
+<p>Wir erheben Daten über Zugriffe auf die Website und speichern diese als "Server-Logfiles" ab. Folgende Daten werden so protokolliert: besuchte Seite, Uhrzeit zum Zeitpunkt des Zugriffes, übertragene Datenmenge, Quelle/Verweis, verwendeter Browser, verwendetes Betriebssystem und IP-Adresse. Die erhobenen Daten dienen lediglich statistischen Auswertungen und zur Verbesserung der Website.</p>
+
+<h2>Umgang mit personenbezogenen Daten</h2>
+<p>Wir verarbeiten personenbezogene Daten nur, wenn dies im gesetzlichen Rahmen erlaubt ist oder wenn Sie in die Datenerhebung einwilligen, etwa im Rahmen einer Registrierung. Die gespeicherten Daten werden ohne Ihre ausdrückliche Zustimmung nicht an Dritte weitergegeben.</p>
+
+<h2>Rechte des Nutzers</h2>
+<p>Sie haben als Nutzer das Recht, auf Antrag eine kostenlose Auskunft darüber zu erhalten, welche personenbezogenen Daten über Sie gespeichert wurden. Sie haben außerdem das Recht auf Berichtigung falscher Daten und auf die Sperrung oder Löschung Ihrer personenbezogenen Daten, soweit dem keine gesetzliche Aufbewahrungspflicht entgegensteht.</p>
+
+<h2>Kontakt</h2>
+<p>Für datenschutzrelevante Anliegen können Sie uns unter den oben angegebenen Kontaktdaten erreichen.</p>
+{% endblock %}

--- a/templates/impressum.html
+++ b/templates/impressum.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Impressum</h1>
+<p>Angaben gem&auml;&szlig; &sect; 5 TMG</p>
+<p>
+Erik Schauer<br>
+Franziskanerh&ouml;he 9<br>
+45139 Essen
+</p>
+<p>
+<strong>Kontakt:</strong><br>
+E-Mail: <a href="mailto:do1ffe@darc.de">do1ffe@darc.de</a>
+</p>
+<p>Verantwortlich f&uuml;r den Inhalt nach &sect; 55 Abs. 2 RStV:<br>
+Erik Schauer, Anschrift wie oben.</p>
+<h2>Haftung f&uuml;r Inhalte</h2>
+<p>Als Diensteanbieter sind wir gem&auml;&szlig; &sect; 7 Abs.1 TMG f&uuml;r eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach &sect;&sect; 8 bis 10 TMG sind wir als Diensteanbieter jedoch nicht verpflichtet, &uuml;bermittelte oder gespeicherte fremde Informationen zu &uuml;berwachen oder nach Umst&auml;nden zu forschen, die auf eine rechtswidrige T&auml;tigkeit hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unber&uuml;hrt. Eine diesbez&uuml;gliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung m&ouml;glich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.</p>
+<h2>Haftung f&uuml;r Links</h2>
+<p>Unser Angebot enth&auml;lt Links zu externen Webseiten Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb k&ouml;nnen wir f&uuml;r diese fremden Inhalte auch keine Gew&auml;hr übernehmen. F&uuml;r die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf m&ouml;gliche Rechtsverst&ouml;&szlig;e &uuml;berpr&uuml;ft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links umgehend entfernen.</p>
+<h2>Urheberrecht</h2>
+<p>Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Vervielf&auml;ltigung, Bearbeitung, Verbreitung und jede Art der Verwertung au&szlig;erhalb der Grenzen des Urheberrechtes bed&uuml;rfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur f&uuml;r den privaten, nicht kommerziellen Gebrauch gestattet. Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte Dritter beachtet. Insbesondere werden Inhalte Dritter als solche gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `datenschutz.html` with privacy policy text
- link Datenschutzerklärung in the footer
- expose `/datenschutz` route in `app.py`

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68471b82c7b083218780d1bd6adf819b