### PR TITLE
Load Stripe keys from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ Es gibt mehrere Abomodelle:
 
 Die Bezahlung kann über PayPal oder per Kreditkarte via Stripe erfolgen.
 Möchtest du deinen Plan wechseln, kündige zunächst das bestehende Abo und wähle anschließend ein neues Modell.
+
+## Konfiguration
+
+Die Anwendung erwartet die Stripe-API-Schlüssel in den Umgebungsvariablen
+`STRIPE_PUBLISHABLE_KEY` und `STRIPE_SECRET_KEY`. Falls diese nicht gesetzt
+sind, werden sie beim Start automatisch aus der Datei `static/STRIPE.KEY`
+geladen. Das Dateiformat entspricht einfachen `KEY=WERT`-Zeilen, z.B.:
+
+```
+STRIPE_PUBLISHABLE_KEY=dein_publishable_key
+STRIPE_SECRET_KEY=dein_secret_key
+```

--- a/app.py
+++ b/app.py
@@ -30,7 +30,24 @@ import qrcode.image.svg
 from PIL import ImageColor
 import stripe
 
+
+def load_stripe_keys_from_file(path="static/STRIPE.KEY"):
+    """Load Stripe API keys from a file if environment variables are unset."""
+    if os.environ.get("STRIPE_SECRET_KEY") and os.environ.get("STRIPE_PUBLISHABLE_KEY"):
+        return
+    if not os.path.exists(path):
+        return
+    with open(path) as f:
+        for line in f:
+            if "=" not in line:
+                continue
+            key, value = line.strip().split("=", 1)
+            os.environ.setdefault(key, value)
+
+
+
 app = Flask(__name__)
+load_stripe_keys_from_file()
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev')
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////home/do1ffe/qrcode/database.db'
 app.config['UPLOAD_FOLDER'] = os.path.join(app.root_path, 'qrcodes')


### PR DESCRIPTION
## Summary
- allow the app to load Stripe API keys from `static/STRIPE.KEY`
- document new Stripe key configuration in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847290ec4748321b33fa6d17746b8aa