### PR TITLE
Add basic admin statistics

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Admin</h1>
+<p><a class="btn btn-warning" href="{{ url_for('admin_stats') }}">Statistiken</a></p>
 <table class="table table-dark table-striped table-hover">
   <thead>
     <tr>

--- a/templates/admin_stats.html
+++ b/templates/admin_stats.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Statistiken</h1>
+<canvas id="userChart" class="mb-4" height="100"></canvas>
+<canvas id="qrChart" class="mb-4" height="100"></canvas>
+<div class="mt-3">
+  <p>Monatliche Abos: <span id="monthly_subs"></span></p>
+  <p>Jährliche Abos: <span id="yearly_subs"></span></p>
+  <p>Umsatz dieses Monats: <span id="month_revenue"></span> €</p>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+fetch('{{ url_for('admin_stats_data') }}')
+  .then(r => r.json())
+  .then(d => {
+    const ctx1 = document.getElementById('userChart');
+    new Chart(ctx1, {
+      type: 'line',
+      data: { labels: d.hours, datasets: [{ label: 'Registrierungen/Std', data: d.user_counts }] },
+      options: { scales: { y: { beginAtZero: true } } }
+    });
+    const ctx2 = document.getElementById('qrChart');
+    new Chart(ctx2, {
+      type: 'line',
+      data: { labels: d.hours, datasets: [{ label: 'QR-Codes/Std', data: d.qr_counts, borderColor: 'orange' }] },
+      options: { scales: { y: { beginAtZero: true } } }
+    });
+    document.getElementById('monthly_subs').textContent = d.monthly_subs;
+    document.getElementById('yearly_subs').textContent = d.yearly_subs;
+    document.getElementById('month_revenue').textContent = d.month_revenue.toFixed(2);
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add registration timestamp and new Payment model
- track payments when upgrading
- create new admin statistics page using Chart.js
- provide stats JSON endpoint and DB upgrade code

## Testing
- `python -m py_compile app.py`
- `pip install -q -r requirements.txt`
- `python app.py` *(fails: sqlite3.OperationalError unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68477c5d7c548321aa75c7d1366facb0