### PR TITLE
Ignore generated QR codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 instance/
 *.pyc
 *.log
+qrcodes/

--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ Eine Kündigung ist jederzeit möglich. Das Abo bleibt jedoch bis zum Ende der b
 
 Die Anwendung erwartet die Stripe-API-Schlüssel in den Umgebungsvariablen
 `STRIPE_PUBLISHABLE_KEY` und `STRIPE_SECRET_KEY`.
+
+Generierte QR-Code-Bilder werden im Verzeichnis `qrcodes/` gespeichert.


### PR DESCRIPTION
## Summary
- add `qrcodes/` to `.gitignore`
- document that `qrcodes/` holds generated QR codes

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847804930f8832191662bfde1fc7833