### PR TITLE
Add admin flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,19 @@ Eine Kündigung ist jederzeit möglich. Das Abo bleibt jedoch bis zum Ende der b
 
 Die Anwendung erwartet die Stripe-API-Schlüssel in den Umgebungsvariablen
 `STRIPE_PUBLISHABLE_KEY` und `STRIPE_SECRET_KEY`.
+
+Um auf den Adminbereich zugreifen zu können, muss ein Benutzer als
+Administrator markiert sein. Der Benutzer **DO1FFE** ist immer automatisch
+Administrator. Weitere Benutzer kannst du nach dem Login über die Admin-Oberfläche
+unter "Benutzer bearbeiten" zum Admin machen.
+
+Alternativ lässt sich ein Konto auch direkt per Python-Shell zum Admin
+machen:
+
+```python
+from app import db, User
+u = User.query.filter_by(username="deinname").first()
+u.is_admin = True
+db.session.commit()
+```
+

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -12,6 +12,7 @@
       <th>Plan</th>
       <th>Upgrade</th>
       <th>QR-Codes</th>
+      <th>Admin</th>
       <th>Aktionen</th>
     </tr>
   </thead>
@@ -25,6 +26,7 @@
       <td>{{ u.plan }}</td>
       <td>{{ u.upgrade_method or '-' }}</td>
       <td>{{ u.qrcodes|length }}</td>
+      <td>{% if u.username == 'DO1FFE' or u.is_admin %}ja{% else %}-{% endif %}</td>
       <td>
         <a class="btn btn-sm btn-info" href="{{ url_for('admin_user_qrcodes', user_id=u.id) }}">QRs</a>
         <a class="btn btn-sm btn-secondary" href="{{ url_for('edit_user', user_id=u.id) }}">Edit</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,7 @@
         <div class="d-flex">
             {% if current_user.is_authenticated %}
                 <span class="navbar-text me-2 text-white">{{ current_user.username }} – {{ current_user.plan|capitalize }}</span>
-                {% if current_user.username == 'DO1FFE' %}
+                {% if current_user.username == 'DO1FFE' or current_user.is_admin %}
                 <a class="btn btn-outline-warning me-2" href="{{ url_for('admin_panel') }}">Admin</a>
                 {% endif %}
                 <a class="btn btn-outline-light me-2" href="{{ url_for('profile') }}">Profil</a>

--- a/templates/edit_user.html
+++ b/templates/edit_user.html
@@ -28,6 +28,10 @@
     <label class="form-label">Upgrade Methode</label>
     <input type="text" class="form-control" name="upgrade_method" value="{{ user.upgrade_method }}">
   </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" name="is_admin" id="is_admin" {% if user.is_admin %}checked{% endif %}>
+    <label class="form-check-label" for="is_admin">Admin</label>
+  </div>
   <button class="btn btn-primary" type="submit">Speichern</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `is_admin` flag to `User`
- use the flag in `is_admin()` checks
- show Admin link based on new flag
- run a migration step to add the column if missing
- document how to promote an account to admin
- allow editing the new admin field in the admin area
- show Admin link for DO1FFE as well
- document promoting users to admin via Python shell

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6847805680e8832194453a2012e4030d