### PR TITLE
Improve error handling throughout QR code app

### DIFF
--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Fehler</h1>
+<p>Es ist ein unerwarteter Fehler aufgetreten. Bitte versuche es erneut.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add global Flask exception handler
- validate colors and file saving in `generate_qr_files`
- wrap QR creation in `index` with try/except
- show user-friendly messages for preview, downloads and deletes
- create an `error.html` template

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68478ce1d18c832197741a9084fb9992