### PR TITLE
Add admin permissions page

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Admin</h1>
-<p><a class="btn btn-warning" href="{{ url_for('admin_stats') }}">Statistiken</a></p>
+<p>
+  <a class="btn btn-warning me-2" href="{{ url_for('admin_stats') }}">Statistiken</a>
+  <a class="btn btn-warning" href="{{ url_for('admin_permissions') }}">Berechtigungen</a>
+</p>
 <table class="table table-dark table-striped table-hover">
   <thead>
     <tr>

--- a/templates/admin_permissions.html
+++ b/templates/admin_permissions.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Dateirechte</h1>
+<table class="table table-dark table-striped table-hover">
+  <thead>
+    <tr>
+      <th>Verzeichnis</th>
+      <th>Lesbar</th>
+      <th>Schreibbar</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for d in dir_info %}
+    <tr>
+      <td>{{ d.path }}</td>
+      <td>{% if d.read %}OK{% else %}<span class="text-danger">Fehler</span>{% endif %}</td>
+      <td>{% if d.write %}OK{% else %}<span class="text-danger">Fehler</span>{% endif %}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create a permissions overview page in admin area
- link to permissions from admin overview
- check DB and user folder permissions

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68478fa3d4748321a9c44551625609bb