### PR TITLE
Add extended admin statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ Die Anwendung erwartet die Stripe-API-Schlüssel in den Umgebungsvariablen
 `STRIPE_PUBLISHABLE_KEY` und `STRIPE_SECRET_KEY`.
 
 Generierte QR-Code-Bilder werden im Verzeichnis `qrcodes/` gespeichert.
+
+Die Admin-Statistikseite zeigt neben den bisherigen Zeitreihendiagrammen nun auch
+Gesamtzahlen, den Gesamtumsatz sowie die Verteilung der Pläne der Nutzer.

--- a/app.py
+++ b/app.py
@@ -649,6 +649,18 @@ def admin_stats_data():
     monthly_subs = db.session.query(func.count(Payment.id)).filter(Payment.period == 'month').scalar() or 0
     yearly_subs = db.session.query(func.count(Payment.id)).filter(Payment.period == 'year').scalar() or 0
 
+    total_users = User.query.count()
+    total_qrcodes = QRCode.query.count()
+    total_revenue = db.session.query(func.sum(Payment.amount)).scalar() or 0
+    active_subs = db.session.query(func.count(User.id)).filter(
+        User.plan != 'basic',
+        User.plan_cancelled.is_(False),
+        User.plan_expires_at > datetime.utcnow(),
+    ).scalar() or 0
+    plan_counts = dict(
+        db.session.query(User.plan, func.count(User.id)).group_by(User.plan).all()
+    )
+
     return {
         'hours': day_labels,
         'user_counts': user_counts,
@@ -656,6 +668,11 @@ def admin_stats_data():
         'monthly_subs': monthly_subs,
         'yearly_subs': yearly_subs,
         'month_revenue': month_revenue / 100.0,
+        'total_users': total_users,
+        'total_qrcodes': total_qrcodes,
+        'total_revenue': total_revenue / 100.0,
+        'active_subs': active_subs,
+        'plan_counts': plan_counts,
     }
 
 

--- a/templates/admin_stats.html
+++ b/templates/admin_stats.html
@@ -3,10 +3,15 @@
 <h1>Statistiken</h1>
 <canvas id="userChart" class="mb-4" height="100"></canvas>
 <canvas id="qrChart" class="mb-4" height="100"></canvas>
+<canvas id="planChart" class="mb-4" height="100"></canvas>
 <div class="mt-3">
   <p>Monatliche Abos: <span id="monthly_subs"></span></p>
   <p>Jährliche Abos: <span id="yearly_subs"></span></p>
   <p>Umsatz dieses Monats: <span id="month_revenue"></span> €</p>
+  <p>Gesamtbenutzer: <span id="total_users"></span></p>
+  <p>Gesamt QR-Codes: <span id="total_qrcodes"></span></p>
+  <p>Gesamtumsatz: <span id="total_revenue"></span> €</p>
+  <p>Aktive Abos: <span id="active_subs"></span></p>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
@@ -25,9 +30,24 @@ fetch('{{ url_for('admin_stats_data') }}')
       data: { labels: d.hours, datasets: [{ label: 'QR-Codes/Std', data: d.qr_counts, borderColor: 'orange' }] },
       options: { scales: { y: { beginAtZero: true } } }
     });
+    const ctx3 = document.getElementById('planChart');
+    new Chart(ctx3, {
+      type: 'pie',
+      data: {
+        labels: Object.keys(d.plan_counts),
+        datasets: [{
+          data: Object.values(d.plan_counts),
+          backgroundColor: ['#0d6efd','#6f42c1','#198754','#ffc107','#dc3545']
+        }]
+      }
+    });
     document.getElementById('monthly_subs').textContent = d.monthly_subs;
     document.getElementById('yearly_subs').textContent = d.yearly_subs;
     document.getElementById('month_revenue').textContent = d.month_revenue.toFixed(2);
+    document.getElementById('total_users').textContent = d.total_users;
+    document.getElementById('total_qrcodes').textContent = d.total_qrcodes;
+    document.getElementById('total_revenue').textContent = d.total_revenue.toFixed(2);
+    document.getElementById('active_subs').textContent = d.active_subs;
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extend admin statistics data with total counts and plan distribution
- visualise plan distribution and totals in admin dashboard
- document new statistics in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6848a99e894083218dc8848b2db71b82