### PR TITLE
Link QR codes to internal pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Die Anwendung nutzt ein modernes Design auf Basis des Minty-Bootswatch-Themes.
 - Download als PNG, JPG oder SVG
 - Zu jedem QR-Code kann eine kurze Beschreibung hinterlegt werden
 - Vorschau der QR-Codes in der Übersicht
+- Beim Scannen öffnet sich zuerst eine Seite der Anwendung, die den hinterlegten
+  Inhalt (z.B. VCARD) anzeigt
 
 ## Pläne
 

--- a/templates/qr_view.html
+++ b/templates/qr_view.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ qr.description or 'QR-Code' }}</h1>
+{% if qr.data_type == 'url' %}
+  <p><a href="{{ qr.url }}" target="_blank">{{ qr.url }}</a></p>
+{% elif qr.data_type == 'text' %}
+  <pre>{{ qr.url }}</pre>
+{% elif qr.data_type == 'email' %}
+  <p>Email: <a href="{{ qr.url }}">{{ qr.url[7:] }}</a></p>
+{% elif qr.data_type == 'phone' %}
+  <p>Telefon: <a href="{{ qr.url }}">{{ qr.url[4:] }}</a></p>
+{% elif qr.data_type == 'sms' %}
+  <p>{{ qr.url }}</p>
+{% elif qr.data_type == 'contact' %}
+  <h2>{{ vcard.name }}</h2>
+  {% if vcard.phone %}<p>Tel: <a href="tel:{{ vcard.phone }}">{{ vcard.phone }}</a></p>{% endif %}
+  {% if vcard.email %}<p>Email: <a href="mailto:{{ vcard.email }}">{{ vcard.email }}</a></p>{% endif %}
+{% else %}
+  <p>{{ qr.url }}</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- generate QR codes that link back to the app
- add new endpoint `/qr/<id>` to display stored content
- add template for showing QR code data
- document that scanned QR codes open an info page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68588ec0471883219c863bbbfdfd4f43