### PR TITLE
Load configuration from .env file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,9 @@
+# Sample environment variables for QR code app
+STRIPE_SECRET_KEY=sk_test_your_secret
+STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable
+PAYPAL_CLIENT_ID=your-paypal-client-id
+PAYPAL_CLIENT_SECRET=your-paypal-client-secret
+# Uncomment to use PayPal sandbox
+#PAYPAL_BASE_URL=https://api-m.sandbox.paypal.com
+SECRET_KEY=change-me
+FLASK_DEBUG=1

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ instance/
 *.pyc
 *.log
 qrcodes/
+.env

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ Fällt dein Plan auf **Basic** zurück, werden automatisch die ältesten QR-Code
 
 ## Konfiguration
 
-Die Anwendung erwartet die Stripe-API-Schlüssel in den Umgebungsvariablen
-`STRIPE_PUBLISHABLE_KEY` und `STRIPE_SECRET_KEY`.
+Die Anwendung lädt ihre Konfigurationswerte aus einer Datei `.env`.
+Trage dort unter anderem deine Stripe-Schlüssel in den Variablen
+`STRIPE_PUBLISHABLE_KEY` und `STRIPE_SECRET_KEY` ein. Eine Vorlage findest du
+in `.env.sample`.
 
 Generierte QR-Code-Bilder werden im Verzeichnis `qrcodes/` gespeichert.
 

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import os
+from dotenv import load_dotenv
 from flask import (
     Flask,
     render_template,
@@ -34,7 +35,8 @@ import stripe
 import secrets
 import string
 
-
+# Load environment variables from a .env file if present
+load_dotenv(os.path.join(os.path.dirname(__file__), '.env'))
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ qrcode[pil]
 Pillow
 requests
 stripe
+python-dotenv


### PR DESCRIPTION
## Summary
- ignore `.env`
- add `python-dotenv` dependency
- load configuration from `.env`
- document `.env` usage and provide `.env.sample`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68756f7cd9cc832189597a535379cb74