### PR TITLE
Add automatic tax to Stripe session

### DIFF
--- a/app.py
+++ b/app.py
@@ -388,6 +388,7 @@ def create_checkout_session(plan):
             success_url=url_for('stripe_success', plan=plan, _external=True) + f'?period={period}&session_id={{CHECKOUT_SESSION_ID}}',
             cancel_url=url_for('upgrade', _external=True),
             customer_email=current_user.email,
+            automatic_tax={'enabled': True},
         )
         return redirect(session.url)
     except Exception as e:


### PR DESCRIPTION
## Summary
- enable automatic tax calculation when creating Stripe Checkout sessions

## Testing
- `python -m py_compile app.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687578b1fe90832194773a825fbfa072