### PR TITLE
Add STRIPE_VERIFY_SSL option

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,8 @@
 # Sample environment variables for QR code app
 STRIPE_SECRET_KEY=sk_test_your_secret
 STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable
+# Set to 0 to disable SSL verification (e.g. behind a proxy)
+STRIPE_VERIFY_SSL=1
 PAYPAL_CLIENT_ID=your-paypal-client-id
 PAYPAL_CLIENT_SECRET=your-paypal-client-secret
 # Uncomment to use PayPal sandbox

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Die Anwendung lädt ihre Konfigurationswerte aus einer Datei `.env`.
 Trage dort unter anderem deine Stripe-Schlüssel in den Variablen
 `STRIPE_PUBLISHABLE_KEY` und `STRIPE_SECRET_KEY` ein. Eine Vorlage findest du
 in `.env.sample`.
+Sollte der Zugriff auf Stripe wegen eines ungeprüften Zertifikats scheitern,
+kannst du mit `STRIPE_VERIFY_SSL=0` die Zertifikatsprüfung deaktivieren.
 
 Generierte QR-Code-Bilder werden im Verzeichnis `qrcodes/` gespeichert.
 

--- a/app.py
+++ b/app.py
@@ -52,6 +52,8 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 # Stripe configuration
 stripe.api_key = os.environ.get('STRIPE_SECRET_KEY')
 STRIPE_PUBLISHABLE_KEY = os.environ.get('STRIPE_PUBLISHABLE_KEY')
+verify_env = os.environ.get('STRIPE_VERIFY_SSL', '1').lower()
+stripe.verify_ssl_certs = verify_env not in ('0', 'false')
 
 
 os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)


### PR DESCRIPTION
## Summary
- allow disabling Stripe SSL verification via `STRIPE_VERIFY_SSL`
- document `STRIPE_VERIFY_SSL` in README and `.env.sample`

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68757d2531c483218fc304f2c2ef56aa