### PR TITLE
Ensure Stripe uses keys from .env

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,8 +35,10 @@ import stripe
 import secrets
 import string
 
-# Load environment variables from a .env file if present
-load_dotenv(os.path.join(os.path.dirname(__file__), '.env'))
+# Load environment variables from a .env file if present.
+# Override existing environment variables to ensure the latest
+# values from the .env file are always used.
+load_dotenv(os.path.join(os.path.dirname(__file__), '.env'), override=True)
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev')


### PR DESCRIPTION
## Summary
- guarantee environment variables are loaded from `.env`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_687582096ea483219c31b6f4dd826748