### PR TITLE
Add style and gradient options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Die Anwendung nutzt ein modernes Design auf Basis des Minty-Bootswatch-Themes.
 
 ## Funktionen
 - Registrierung (mit Email) und Login per Benutzername und Passwort
-- Generieren von QR-Codes mit Farbe, Hintergrundfarbe und runden Ecken
+- Generieren von QR-Codes mit Farbe, Hintergrundfarbe, verschiedenen Stilen und optionalem Farbverlauf
 - Größe der QR-Codes passt sich automatisch dem Inhalt an
 - Verschiedene Inhalte möglich: URL, Text, Email, Telefon, SMS oder Kontaktdaten
 - QR-Codes werden pro Benutzer gespeichert

--- a/templates/index.html
+++ b/templates/index.html
@@ -66,13 +66,27 @@
     <label class="form-label">Hintergrund</label>
     <input type="color" class="form-control form-control-color" name="bgcolor" value="#ffffff">
   </div>
+  <div class="col-md-2">
+    <label class="form-label">Stil</label>
+    <select class="form-select" name="style">
+      <option value="square">Eckig</option>
+      <option value="rounded">Abgerundet</option>
+      <option value="circle">Kreis</option>
+      <option value="vertical">Vertikale Balken</option>
+      <option value="horizontal">Horizontale Balken</option>
+    </select>
+  </div>
+  <div class="col-md-2 form-check">
+    <input class="form-check-input" type="checkbox" name="gradient" id="gradient">
+    <label class="form-check-label" for="gradient">Verlauf</label>
+  </div>
+  <div class="col-md-2 d-none" id="gradcolor-group">
+    <label class="form-label">Verlauffarbe</label>
+    <input type="color" class="form-control form-control-color" name="gradcolor" value="#ff0000">
+  </div>
   <div class="col-md-12">
     <label class="form-label">Beschreibung</label>
     <input type="text" class="form-control" name="description">
-  </div>
-  <div class="col-md-12 form-check">
-    <input class="form-check-input" type="checkbox" name="rounded" id="rounded">
-    <label class="form-check-label" for="rounded">Runde Ecken</label>
   </div>
   <div class="col-12">
     <button type="submit" class="btn btn-primary" {% if limit_reached %}disabled{% endif %}>Erstellen</button>
@@ -130,12 +144,17 @@ function updateFields() {
     el.classList.add('d-none');
     el.querySelectorAll('input').forEach(inp => (inp.required = false));
   });
-  document.querySelectorAll('.data-' + type).forEach(el => {
+document.querySelectorAll('.data-' + type).forEach(el => {
     el.classList.remove('d-none');
     el.querySelectorAll('input').forEach(inp => (inp.required = true));
   });
 }
 document.getElementById('data_type').addEventListener('change', updateFields);
-document.addEventListener('DOMContentLoaded', updateFields);
+function toggleGradient() {
+  const chk = document.getElementById('gradient');
+  document.getElementById('gradcolor-group').classList.toggle('d-none', !chk.checked);
+}
+document.getElementById('gradient').addEventListener('change', toggleGradient);
+document.addEventListener('DOMContentLoaded', () => { updateFields(); toggleGradient(); });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow picking QR code style and gradient on create
- generate QR codes with different module shapes and optional gradient
- document new customization features

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688104a591c08321899ff19e54546f0c